### PR TITLE
Refactor: Pass ParseTree to AstBuilder to access source

### DIFF
--- a/Libraries/Irony/Irony/Parsing/Terminals/RegexBasedTerminal.cs
+++ b/Libraries/Irony/Irony/Parsing/Terminals/RegexBasedTerminal.cs
@@ -69,9 +69,7 @@ namespace Irony.Parsing {
       if (!m.Success || m.Index != source.PreviewPosition) 
         return null;
       source.PreviewPosition += m.Length;
-      Token token = source.CreateToken(this.OutputTerminal);
-      token.Details = source.Text;
-      return token;
+      return source.CreateToken(this.OutputTerminal);
     }
 
   }//class

--- a/Source/System.Management/Pash/Implementation/Parser.cs
+++ b/Source/System.Management/Pash/Implementation/Parser.cs
@@ -31,7 +31,7 @@ namespace Pash.Implementation
         public static ScriptBlockAst ParseInput(string input)
         {
             var parseTree = Parse(input, false);
-            return new AstBuilder(Grammar).BuildScriptBlockAst(parseTree.Root);;
+            return new AstBuilder(Grammar, parseTree).BuildScriptBlockAst(parseTree.Root);
         }
 
         public static bool TryParsePartialInput(string input, out ScriptBlockAst scriptBlock)
@@ -48,7 +48,7 @@ namespace Pash.Implementation
             var parseTree = Parse(input, true);
             if (parseTree.Status.Equals(ParseTreeStatus.Parsed))
             {
-                scriptBlock = new AstBuilder(Grammar).BuildScriptBlockAst(parseTree.Root);
+                scriptBlock = new AstBuilder(Grammar, parseTree).BuildScriptBlockAst(parseTree.Root);
                 return true;
             }
             // if we're here we only partially parsed, because Parse would have thrown on error

--- a/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
+++ b/Source/System.Management/Pash/ParserIntrinsics/AstBuilder.cs
@@ -20,10 +20,12 @@ namespace Pash.ParserIntrinsics
     class AstBuilder
     {
         readonly PowerShellGrammar _grammar;
+        readonly ParseTree _parseTree;
 
-        public AstBuilder(PowerShellGrammar grammar)
+        public AstBuilder(PowerShellGrammar grammar, ParseTree parseTree)
         {
-            this._grammar = grammar;
+            _grammar = grammar;
+            _parseTree = parseTree;
         }
 
         [Conditional("DEBUG")]
@@ -1562,9 +1564,8 @@ namespace Pash.ParserIntrinsics
             }
 
             var extent = (IScriptExtent) new ScriptExtent(parseTreeNode);
-            var completeText = parseTreeNode.ChildNodes.First().Token.Details.ToString();
             // now strip the real text value. +1 and -2 are used to strip the quotes
-            var textValue = completeText.Substring(extent.StartOffset + 1, extent.EndOffset - extent.StartOffset - 2);
+            var textValue = _parseTree.SourceText.Substring(extent.StartOffset + 1, extent.EndOffset - extent.StartOffset - 2);
             return new ExpandableStringExpressionAst(
                 extent, toResolve, textValue,
                 StringConstantType.DoubleQuoted);


### PR DESCRIPTION
This way it's not necessary to save it in a modified RegexBasedTerminal.